### PR TITLE
Adds Indices to References Conversion Algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+*.vim

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ stable_deref_trait = "1.2.0"
 heapless = { version = "0.7.7", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 alloc-traits = "0.1.1"
+
+[dev-dependencies]
+static-alloc = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ std = ["serde/std"]
 executing = []
 
 [dependencies]
+stable_deref_trait = "1.2.0"
 heapless = { version = "0.7.7", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 alloc-traits = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [features]
 default = ["std"]
 std = ["serde/std"]
-executing = []
 
 [dependencies]
 stable_deref_trait = "1.2.0"

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -124,40 +124,6 @@ fn alloc_struct<T>(obj: T, alloc: &'static dyn LocalAlloc<'static>) -> Option<&'
     Some(unsafe { &*ptr })
 }
 
-pub fn refs_to_indices(config: &reference::ConfigFile) -> index::ConfigFile {
-    /*
-    use heapless::Vec;
-    let mut states: Vec<_, MAX_STATES> = config
-        .states
-        .iter()
-        .map(|a| index::State::new(Vec::new(), Vec::new(), None))
-        .collect();
-
-    for (dst_state, src_state) in states.iter_mut().zip(config.states.iter().copied()) {
-        dst_state.timeout = src_state.timeout.as_ref().map(|src_timeout| {
-            let transition = transition_ref_to_index(&src_timeout.transition, &config.states);
-            index::Timeout::new(src_timeout.time, transition)
-        });
-
-        for src_check in src_state.checks {
-            let transition = transition_ref_to_index(&src_check.transition, &config.states);
-            let check = index::Check {
-                object: src_check.object,
-                condition: src_check.condition,
-                transition,
-            };
-            dst_state.checks.push(check).unwrap();
-        }
-
-        for src_command in src_state.commands.iter() {
-            dst_state.commands.push((*src_command).into());
-        }
-    }
-    */
-
-    todo!()
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -74,7 +74,7 @@ pub fn indices_to_refs(
         }
 
         for command in state.commands.iter() {
-            let ref_command = alloc_struct(command.clone(), alloc).unwrap();
+            let ref_command = alloc_struct(command_index_to_ref(command), alloc).unwrap();
             if ref_state.commands.push(ref_command).is_err() {
                 // The size of `index::State::commands` and `reference::State::commands` is determined
                 // by the same constant, so it is impossible to for one vector to have more
@@ -91,6 +91,10 @@ pub fn indices_to_refs(
     }
 
     Some(init)
+}
+
+fn command_index_to_ref(command: &index::Command) -> reference::Command {
+    reference::Command::new(command.object, command.delay)
 }
 
 fn transition_index_to_ref<'s>(
@@ -127,17 +131,18 @@ fn alloc_struct<T>(obj: T, alloc: &'static dyn LocalAlloc<'static>) -> Option<&'
 #[cfg(test)]
 mod tests {
     use crate::{
-        index::{Check, ConfigFile, State, StateIndex, StateTransition, Timeout},
-        indices_to_refs, CheckData, Command, CommandObject, FloatCondition, NativeFlagCondition,
+        index::{Check, Command, ConfigFile, State, StateIndex, StateTransition, Timeout},
+        indices_to_refs, CheckData, CommandObject, FloatCondition, NativeFlagCondition,
         PyroContinuityCondition, Seconds, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES,
     };
     use heapless::Vec;
     use static_alloc::Bump;
 
-    const STATE_SIZE: usize = core::mem::size_of::<State>() * MAX_STATES;
-    const CHECK_SIZE: usize = core::mem::size_of::<Check>() * MAX_CHECKS_PER_STATE * MAX_STATES;
+    const STATE_SIZE: usize = core::mem::size_of::<crate::reference::State>() * MAX_STATES;
+    const CHECK_SIZE: usize =
+        core::mem::size_of::<crate::reference::Check>() * MAX_CHECKS_PER_STATE * MAX_STATES;
     const COMMAND_SIZE: usize =
-        core::mem::size_of::<Command>() * MAX_COMMANDS_PER_STATE * MAX_STATES;
+        core::mem::size_of::<crate::reference::Command>() * MAX_COMMANDS_PER_STATE * MAX_STATES;
     const BUMP_SIZE: usize = STATE_SIZE + CHECK_SIZE + COMMAND_SIZE;
 
     static A: Bump<[u8; BUMP_SIZE]> = Bump::uninit();

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -54,7 +54,7 @@ pub fn indices_to_refs(
 
     // Now that each state is initialized, we can add the proper checks, commands, and timeouts
     for (i, state) in config.states.iter().enumerate() {
-        let ref_state = init.get(i).unwrap();
+        let ref_state = &init[i];
 
         for check in state.checks.iter() {
             let transition = check
@@ -69,7 +69,7 @@ pub fn indices_to_refs(
                 // The size of `index::State::checks` and `reference::State::checks` is determined
                 // by the same constant, so it is impossible to for one vector to have more
                 // elements than the capacity of the other
-                panic!("State checks exceeded maxmimum number of checks allowed");
+                unreachable!("State checks exceeded maxmimum number of checks allowed");
             }
         }
 
@@ -79,7 +79,7 @@ pub fn indices_to_refs(
                 // The size of `index::State::commands` and `reference::State::commands` is determined
                 // by the same constant, so it is impossible to for one vector to have more
                 // elements than the capacity of the other
-                panic!("State commands exceeded maxmimum number of commands allowed");
+                unreachable!("State commands exceeded maxmimum number of commands allowed");
             }
         }
 

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -74,7 +74,7 @@ pub fn indices_to_refs(
         }
 
         for command in state.commands.iter() {
-            let ref_command = alloc_struct(*command, alloc).unwrap();
+            let ref_command = alloc_struct(command.clone(), alloc).unwrap();
             if ref_state.commands.push(ref_command).is_err() {
                 // The size of `index::State::commands` and `reference::State::commands` is determined
                 // by the same constant, so it is impossible to for one vector to have more

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -74,7 +74,7 @@ pub fn indices_to_refs(
         }
 
         for command in state.commands.iter() {
-            let ref_command = alloc_struct(command.clone(), alloc).unwrap();
+            let ref_command = alloc_struct(*command, alloc).unwrap();
             if ref_state.commands.push(ref_command).is_err() {
                 // The size of `index::State::commands` and `reference::State::commands` is determined
                 // by the same constant, so it is impossible to for one vector to have more

--- a/src/frozen.rs
+++ b/src/frozen.rs
@@ -1,0 +1,238 @@
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+
+use stable_deref_trait::StableDeref;
+
+/// A fixed capacity, heapless `FrozenVec` from the `elsa` crate implementation
+///
+/// use frozen::FrozenVec;
+///
+/// let vec = FrozenVec::<u32, 8>::new();
+///
+/// let x = 2;
+/// let y = 4;
+///
+/// vec.push(&x);
+/// vec.push(&y);
+///
+pub struct FrozenVec<T, const N: usize> {
+    buffer: UnsafeCell<[MaybeUninit<T>; N]>,
+    len: UnsafeCell<usize>,
+}
+
+impl<T: StableDeref, const N: usize> FrozenVec<T, N> {
+    const INIT: MaybeUninit<T> = MaybeUninit::uninit();
+
+    /// Constructs a new, empty vector with a fixed capacity of `N`
+    pub fn new() -> Self {
+        Self {
+            buffer: UnsafeCell::new([Self::INIT; N]),
+            len: UnsafeCell::new(0),
+        }
+    }
+
+    /// Appends an `item` to the back of the collection
+    ///
+    /// Returns back the `item` if the vector is full
+    pub fn push(&self, item: T) -> Result<(), T> {
+        if self.len() < self.capacity() {
+            // SAFETY: We have already performed the bounds check to see if we have exceeded our
+            // capacity
+            unsafe { self.push_unchecked(item) }
+            Ok(())
+        } else {
+            Err(item)
+        }
+    }
+
+    /// Appends an `item` to the back of the collection, but immediately return a shared reference
+    /// to it
+    pub fn push_get(&self, item: T) -> Result<&T::Target, T> {
+        self.push(item)?;
+
+        // SAFETY: We have just pushed an element and if it failed, it would have already returned.
+        // Therefore self.len() - 1 is at least 0
+        unsafe { Ok(self.get_unchecked(self.len() - 1)) }
+    }
+
+    /// Appends an `item` to the back of the collection
+    ///
+    /// # SAFETY:
+    /// This assumes the vector is not full
+    pub unsafe fn push_unchecked(&self, item: T) {
+        debug_assert!(!self.is_full());
+
+        let current_len = self.len();
+
+        // SAFETY:
+        // 1. This FrozenVec is !Send, so we are the only ones accessing this UnsafeCell.
+        // 2. The buffer consists of MaybeUninit<T> instead of raw T, so we can directly write into
+        //    the array instead of using ptr::write because MaybeUninit will never drop the inner
+        //    T, so we won't be dropping random garbage.
+        let buffer = &mut *(self.buffer.get());
+        *buffer.get_unchecked_mut(current_len) = MaybeUninit::new(item);
+
+        // SAFETY: We are the only ones currently borrowing len, as it is impossible to do from
+        // safe code, and we give up our mutable reference here immediately, as does any other
+        // function on Self
+        let len = &mut *(self.len.get());
+        *len = current_len + 1;
+    }
+
+    /// Returns a reference to an element
+    pub fn get(&self, index: usize) -> Option<&T::Target> {
+        // SAFETY:
+        // 1. We never borrow our internal buffer, and instead use raw pointers to index it as a
+        //    slice, allowing us to dereference one of our buffers' T: StableDeref's which are
+        //    themselves borrowed instead of any part of our buffer
+        unsafe {
+            let buffer = self.buffer.get();
+            (*buffer).get(index).map(|x| x.assume_init_ref().deref())
+        }
+    }
+
+    /// Returns a reference to an element, without doing bounds checking.
+    ///
+    /// # SAFETY:
+    ///
+    /// `index` must be in bounds, i.e. it must be less than `self.len()`
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T::Target {
+        // SAFETY:
+        // 1. We never borrow our internal buffer, and instead use raw pointers to index it as a
+        //    slice, allowing us to dereference one of our buffers' T: StableDeref's which are
+        //    themselves borrowed instead of any part of our buffer
+        // 2. The bounds check was performed prior to this function call
+        let buffer = self.buffer.get();
+        (*buffer).get_unchecked(index).assume_init_ref().deref()
+    }
+
+    /// Returns an iterator over the vector.
+    pub fn iter(&self) -> Iter<T, N> {
+        self.into_iter()
+    }
+
+    /// Returns true if the vector is full
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.len() == self.capacity()
+    }
+
+    /// Returns true if the vector is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the current length of the vector (the number of elements currently stored in it)
+    ///
+    /// NOTE: This is not the capacity of the vector, which is the maximum number of elements that
+    /// can be stored.
+    #[inline]
+    pub fn len(&self) -> usize {
+        // SAFETY: Here we completely bypass creating a reference and only read the value from
+        // self.len. Therefore this will always be valid
+        unsafe { *self.len.get() }
+    }
+
+    /// Returns the maximum number of elements the vector can hold
+    pub fn capacity(&self) -> usize {
+        N
+    }
+}
+
+/// Iterator over FrozenVec, obtained via `.iter()`
+///
+/// It is safe to push to the vector during iteration
+pub struct Iter<'a, T, const N: usize> {
+    vec: &'a FrozenVec<T, N>,
+    idx: usize,
+}
+
+impl<'a, T: StableDeref, const N: usize> Iterator for Iter<'a, T, N> {
+    type Item = &'a T::Target;
+    fn next(&mut self) -> Option<&'a T::Target> {
+        if let Some(ret) = self.vec.get(self.idx) {
+            self.idx += 1;
+            Some(ret)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T: StableDeref, const N: usize> IntoIterator for &'a FrozenVec<T, N> {
+    type Item = &'a T::Target;
+    type IntoIter = Iter<'a, T, N>;
+    fn into_iter(self) -> Iter<'a, T, N> {
+        Iter { vec: self, idx: 0 }
+    }
+}
+
+impl<T: StableDeref, const N: usize> Default for FrozenVec<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[test]
+fn test_iteration() {
+    use heapless::Vec;
+
+    let v: FrozenVec<&u32, 6> = FrozenVec::new();
+    let mut h: Vec<&u32, 6> = Vec::new();
+
+    let x = 0;
+    let y = 2;
+    let z = 4;
+    let a = 7;
+    let b = 9;
+    let c = 11;
+
+    v.push(&x).unwrap();
+    v.push(&y).unwrap();
+    v.push(&z).unwrap();
+    v.push(&a).unwrap();
+    v.push(&b).unwrap();
+    v.push(&c).unwrap();
+
+    h.push(&x).unwrap();
+    h.push(&y).unwrap();
+    h.push(&z).unwrap();
+    h.push(&a).unwrap();
+    h.push(&b).unwrap();
+    h.push(&c).unwrap();
+
+    for (e1, e2) in h.iter().zip(v.iter()) {
+        assert_eq!(*e1, e2);
+    }
+
+    assert_eq!(h.len(), v.iter().count());
+
+    // We need to drop this first
+    drop(h);
+}
+
+#[test]
+fn test_accessors() {
+    let vec: FrozenVec<&u32, 8> = FrozenVec::new();
+
+    let x = 0;
+    let y = 2;
+    let z = 4;
+
+    assert_eq!(vec.is_empty(), true);
+    assert_eq!(vec.len(), 0);
+    // assert_eq!(vec.first(), None);
+    // assert_eq!(vec.last(), None);
+    assert_eq!(vec.get(1), None);
+
+    vec.push(&x).unwrap();
+    vec.push(&y).unwrap();
+    vec.push(&z).unwrap();
+
+    assert_eq!(vec.is_empty(), false);
+    assert_eq!(vec.len(), 3);
+    // assert_eq!(vec.first(), Some("a"));
+    // assert_eq!(vec.last(), Some("c"));
+    assert_eq!(vec.get(1), Some(&y));
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,7 @@
 //! State machine data structures that use indices to reference state transitions.
 //! This is needed when the config file is serialized between the verifier and the flight computer.
 
-use crate::{MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
+use crate::{Command, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
 
 use heapless::Vec;
 use serde::{Deserialize, Serialize};
@@ -92,22 +92,6 @@ pub struct Check {
 impl Check {
     pub fn new(data: crate::CheckData, transition: Option<StateTransition>) -> Self {
         Self { data, transition }
-    }
-}
-
-/// An action that takes place at a specific time after the state containing this is entered
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
-pub struct Command {
-    /// The object that this command will act upon
-    pub object: crate::CommandObject,
-
-    /// How long after the state activates to execute this command
-    pub delay: crate::Seconds,
-}
-
-impl Command {
-    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
-        Self { object, delay }
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,7 +14,7 @@ pub struct ConfigFile {
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
-/// The which references a particural state
+/// The which references a particular state
 pub struct StateIndex(u8);
 
 impl StateIndex {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,7 @@
 //! State machine data structures that use indices to reference state transitions.
 //! This is needed when the config file is serialized between the verifier and the flight computer.
 
-use crate::{Command, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
+use crate::{MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
 
 use heapless::Vec;
 use serde::{Deserialize, Serialize};
@@ -105,6 +105,22 @@ pub enum StateTransition {
     Transition(StateIndex),
     /// Represents an abort to a safer state if an abort condition was met
     Abort(StateIndex),
+}
+
+/// An action that takes place at a specific time after the state containing this is entered
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
+pub struct Command {
+    /// The object that this command will act upon
+    pub object: crate::CommandObject,
+
+    /// How long after the state activates to execute this command
+    pub delay: crate::Seconds,
+}
+
+impl Command {
+    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
+        Self { object, delay }
+    }
 }
 
 #[cfg(test)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -30,8 +30,8 @@ impl StateIndex {
     /// This wrapper simply allows us to feel better about unwrapping `get()`s that use index at
     /// other places in the codebase because we assume constructing an invalid `StateIndex` is
     /// impossible
-    pub unsafe fn new_unchecked(index: usize) -> Self {
-        StateIndex(index as u8)
+    pub unsafe fn new_unchecked(index: u8) -> Self {
+        StateIndex(index)
     }
 }
 
@@ -49,14 +49,14 @@ impl From<StateIndex> for usize {
 pub struct State {
     //pub name: String<16>,
     pub checks: Vec<Check, MAX_CHECKS_PER_STATE>,
-    pub commands: Vec<crate::Command, MAX_COMMANDS_PER_STATE>,
+    pub commands: Vec<Command, MAX_COMMANDS_PER_STATE>,
     pub timeout: Option<Timeout>,
 }
 
 impl State {
     pub fn new(
         checks: Vec<Check, MAX_CHECKS_PER_STATE>,
-        commands: Vec<crate::Command, MAX_COMMANDS_PER_STATE>,
+        commands: Vec<Command, MAX_COMMANDS_PER_STATE>,
         timeout: Option<Timeout>,
     ) -> Self {
         Self {
@@ -85,22 +85,29 @@ impl Timeout {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Check {
     //pub name: String<16>,
-    pub object: crate::CheckObject,
-    pub condition: crate::CheckCondition,
-    pub transition: StateTransition,
+    pub data: crate::CheckData,
+    pub transition: Option<StateTransition>,
 }
 
 impl Check {
-    pub fn new(
-        object: crate::CheckObject,
-        condition: crate::CheckCondition,
-        transition: StateTransition,
-    ) -> Self {
-        Self {
-            object,
-            condition,
-            transition,
-        }
+    pub fn new(data: crate::CheckData, transition: Option<StateTransition>) -> Self {
+        Self { data, transition }
+    }
+}
+
+/// An action that takes place at a specific time after the state containing this is entered
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
+pub struct Command {
+    /// The object that this command will act upon
+    pub object: crate::CommandObject,
+
+    /// How long after the state activates to execute this command
+    pub delay: crate::Seconds,
+}
+
+impl Command {
+    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
+        Self { object, delay }
     }
 }
 
@@ -116,7 +123,11 @@ pub enum StateTransition {
     Abort(StateIndex),
 }
 
-#[test]
-fn test() {
-    assert_eq!(core::mem::size_of::<ConfigFile>(), 0);
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn test() {
+        assert_eq!(core::mem::size_of::<crate::index::ConfigFile>(), 1608);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 pub mod conversions;
+pub mod frozen;
 pub mod index;
 pub mod reference;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@ pub const MAX_COMMANDS_PER_STATE: usize = 3;
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "executing")]
-use core::sync::atomic::AtomicBool;
-
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
 pub struct Seconds(pub f32);
 
@@ -64,29 +61,4 @@ pub enum CommandObject {
     Pyro3(bool),
     Beacon(bool),
     DataRate(u16),
-}
-
-/// An action that takes place at a specific time after the state containing this is entered
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct Command {
-    /// The object that this command will act upon
-    pub object: crate::CommandObject,
-
-    /// How long after the state activates to execute this command
-    pub delay: crate::Seconds,
-
-    /// If this command has already executed
-    #[cfg(feature = "executing")]
-    pub was_executed: AtomicBool,
-}
-
-impl Command {
-    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
-        Self {
-            object,
-            delay,
-            #[cfg(feature = "executing")]
-            was_executed: AtomicBool::new(false),
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub enum CommandObject {
 }
 
 /// An action that takes place at a specific time after the state containing this is entered
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Command {
     /// The object that this command will act upon
     pub object: crate::CommandObject,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub const MAX_COMMANDS_PER_STATE: usize = 3;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "executing")]
+use core::sync::atomic::AtomicBool;
+
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
 pub struct Seconds(pub f32);
 
@@ -63,11 +66,27 @@ pub enum CommandObject {
     DataRate(u16),
 }
 
-impl From<&crate::reference::Command> for index::Command {
-    fn from(c: &crate::reference::Command) -> Self {
+/// An action that takes place at a specific time after the state containing this is entered
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
+pub struct Command {
+    /// The object that this command will act upon
+    pub object: crate::CommandObject,
+
+    /// How long after the state activates to execute this command
+    pub delay: crate::Seconds,
+
+    /// If this command has already executed
+    #[cfg(feature = "executing")]
+    pub was_executed: AtomicBool,
+}
+
+impl Command {
+    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
         Self {
-            object: c.object,
-            delay: c.delay,
+            object,
+            delay,
+            #[cfg(feature = "executing")]
+            was_executed: AtomicBool::new(false),
         }
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -3,9 +3,10 @@
 //! reference a different state is important
 
 use core::cell::Cell;
+use core::sync::atomic::AtomicBool;
 use heapless::Vec;
 
-use crate::{frozen::FrozenVec, Command, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
+use crate::{frozen::FrozenVec, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
 
 pub struct ConfigFile<'s> {
     pub default_state: &'s State<'s>,
@@ -70,4 +71,27 @@ impl<'s> Check<'s> {
 pub enum StateTransition<'s> {
     Transition(&'s State<'s>),
     Abort(&'s State<'s>),
+}
+
+/// An action that takes place at a specific time after the state containing this is entered
+#[derive(Debug)]
+pub struct Command {
+    /// The object that this command will act upon
+    pub object: crate::CommandObject,
+
+    /// How long after the state activates to execute this command
+    pub delay: crate::Seconds,
+
+    /// If this command has already executed
+    pub was_executed: AtomicBool,
+}
+
+impl Command {
+    pub fn new(object: crate::CommandObject, delay: crate::Seconds) -> Self {
+        Self {
+            object,
+            delay,
+            was_executed: AtomicBool::new(false),
+        }
+    }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -2,15 +2,10 @@
 //! This module's types are uses as opposed to [`index`] during runtime, when being able to easily
 //! reference a different state is important
 
-#[cfg(feature = "executing")]
-use core::sync::atomic::AtomicBool;
-
 use core::cell::Cell;
 use heapless::Vec;
 
-use crate::{
-    frozen::FrozenVec, index, Seconds, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES,
-};
+use crate::{frozen::FrozenVec, Command, MAX_CHECKS_PER_STATE, MAX_COMMANDS_PER_STATE, MAX_STATES};
 
 pub struct ConfigFile<'s> {
     pub default_state: &'s State<'s>,
@@ -75,22 +70,4 @@ impl<'s> Check<'s> {
 pub enum StateTransition<'s> {
     Transition(&'s State<'s>),
     Abort(&'s State<'s>),
-}
-
-pub struct Command {
-    pub object: crate::CommandObject,
-    pub delay: Seconds,
-    #[cfg(feature = "executing")]
-    pub was_executed: AtomicBool,
-}
-
-impl From<&index::Command> for Command {
-    fn from(c: &index::Command) -> Self {
-        Self {
-            object: c.object,
-            delay: c.delay,
-            #[cfg(feature = "executing")]
-            was_executed: AtomicBool::new(false),
-        }
-    }
 }


### PR DESCRIPTION
Created a heapless append-only Vec implementation which allows us to safely modify states using only a shared reference.
Added an algorithm to convert from the index-based states read from the configuration file to the version suitable for execution.